### PR TITLE
Fixing links to PDF files

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,8 +180,8 @@ eventbrite: "29157755632"          # optional: alphanumeric key for Eventbrite r
   Please read the following before the workshop begins:
 </p>
 <ol>
-  <li><a href="{{ site.training_site }}/papers/porter-what-works-2013.pdf">Success in Introductory Programming: What Works?</a></li>
-  <li><a href="{{ site.training_site }}/papers/science-of-learning-2015.pdf">The Science of Learning</a></li>
+  <li><a href="https://carpentries.github.io/instructor-training/papers/porter-what-works-2013.pdf">Success in Introductory Programming: What Works?</a></li>
+  <li><a href="https://carpentries.github.io/instructor-training/papers/science-of-learning-2015.pdf">The Science of Learning</a></li>
 </ol>
 <p>
   Please also read through <em>one</em> of the episodes below


### PR DESCRIPTION
currently, site.training_site points to https://swcarpentry.github.io website. Fix that temporary until it is fixed upstream.
